### PR TITLE
Always set RIOTBASE to point to the submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 
 # ---- RIOT specific configuration ----
 # This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/RIOT
+RIOTBASE = $(CURDIR)/RIOT
 
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native


### PR DESCRIPTION
To avoid possible version issues if users already has RIOTBASE defined to something else.