### PR TITLE
Fix lfc build not invoked and LF_LOG_LEVEL_ERR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LF_MAIN ?= HelloWorld
 # CFLAGS += -DNETWORK_CHANNEL_COAP_RIOT
 
 # Make default debug output report only info and errors.
-CFLAGS += -DLF_LOG_LEVEL_ALL=LF_LOG_LEVEL_ERR
+CFLAGS += -DLF_LOG_LEVEL_ALL=LF_LOG_LEVEL_ERROR
 
 # Execute the LF compiler if build target is "all"
 ifeq ($(firstword $(MAKECMDGOALS)),all)

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LF_MAIN ?= HelloWorld
 CFLAGS += -DLF_LOG_LEVEL_ALL=LF_LOG_LEVEL_ERR
 
 # Execute the LF compiler if build target is "all"
-ifeq ($(MAKECMDGOALS),all)
+ifeq ($(firstword $(MAKECMDGOALS)),all)
   _ :=  $(shell $(REACTOR_UC_PATH)/lfc/bin/lfc-dev src/$(LF_MAIN).lf)
 endif
 


### PR DESCRIPTION
1. `LF_LOG_LEVEL_ERR` has been renamed to `LF_LOG_LEVEL_ERROR`
2. Calling `make all term` did not invoke the `lfc`. Now it does.
